### PR TITLE
feat: added `refresh` and `reset` methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@matrixai/async-cancellable": "^1.0.2"
       },
       "devDependencies": {
+        "@matrixai/errors": "^1.1.7",
         "@swc/core": "^1.2.215",
         "@types/jest": "^28.1.3",
         "@types/node": "^16.11.7",
@@ -1122,6 +1123,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@matrixai/async-cancellable/-/async-cancellable-1.0.2.tgz",
       "integrity": "sha512-ugMfKtp7MlhXfBP//jGEAEEDbkVlr1aw8pqe2NrEUyyfKrZlX2jib50YocQYf+CcP4XnFAEzBDIpTAmqjukCug=="
+    },
+    "node_modules/@matrixai/errors": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@matrixai/errors/-/errors-1.1.7.tgz",
+      "integrity": "sha512-WD6MrlfgtNSTfXt60lbMgwasS5T7bdRgH4eYSOxV+KWngqlkEij9EoDt5LwdvcMD1yuC33DxPTnH4Xu2XV3nMw==",
+      "dev": true,
+      "dependencies": {
+        "ts-custom-error": "3.2.2"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5549,6 +5559,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-custom-error": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.2.2.tgz",
+      "integrity": "sha512-u0YCNf2lf6T/vHm+POKZK1yFKWpSpJitcUN3HxqyEcFuNnHIDbyuIQC7QDy/PsBX3giFyk9rt6BFqBAh2lsDZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "28.0.7",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.7.tgz",
@@ -6945,6 +6964,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@matrixai/async-cancellable/-/async-cancellable-1.0.2.tgz",
       "integrity": "sha512-ugMfKtp7MlhXfBP//jGEAEEDbkVlr1aw8pqe2NrEUyyfKrZlX2jib50YocQYf+CcP4XnFAEzBDIpTAmqjukCug=="
+    },
+    "@matrixai/errors": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@matrixai/errors/-/errors-1.1.7.tgz",
+      "integrity": "sha512-WD6MrlfgtNSTfXt60lbMgwasS5T7bdRgH4eYSOxV+KWngqlkEij9EoDt5LwdvcMD1yuC33DxPTnH4Xu2XV3nMw==",
+      "dev": true,
+      "requires": {
+        "ts-custom-error": "3.2.2"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10151,6 +10179,12 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "ts-custom-error": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.2.2.tgz",
+      "integrity": "sha512-u0YCNf2lf6T/vHm+POKZK1yFKWpSpJitcUN3HxqyEcFuNnHIDbyuIQC7QDy/PsBX3giFyk9rt6BFqBAh2lsDZQ==",
+      "dev": true
     },
     "ts-jest": {
       "version": "28.0.7",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^16.11.7",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
+    "@matrixai/errors": "^1.1.7",
     "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",

--- a/src/ErrorTimer.ts
+++ b/src/ErrorTimer.ts
@@ -1,0 +1,43 @@
+import type { Class } from '@matrixai/errors';
+import { AbstractError } from '@matrixai/errors';
+
+class ErrorPolykey<T> extends AbstractError<T> {
+  static description: string = 'Polykey error';
+  exitCode: number = 1; // GENERAL error
+
+  public static fromJSON<T extends Class<any>>(
+    this: T,
+    json: any,
+  ): InstanceType<T> {
+    if (
+      typeof json !== 'object' ||
+      json.type !== this.name ||
+      typeof json.data !== 'object' ||
+      typeof json.data.message !== 'string' ||
+      isNaN(Date.parse(json.data.timestamp)) ||
+      typeof json.data.description !== 'string' ||
+      typeof json.data.data !== 'object' ||
+      typeof json.data.exitCode !== 'number' ||
+      ('stack' in json.data && typeof json.data.stack !== 'string')
+    ) {
+      throw new TypeError(`Cannot decode JSON to ${this.name}`);
+    }
+    const e = new this(json.data.message, {
+      timestamp: new Date(json.data.timestamp),
+      data: json.data.data,
+      cause: json.data.cause,
+    });
+    e.exitCode = json.data.exitCode;
+    e.stack = json.data.stack;
+    return e;
+  }
+
+  public toJSON(): any {
+    const json = super.toJSON();
+    json.data.description = this.description;
+    json.data.exitCode = this.exitCode;
+    return json;
+  }
+}
+
+export default ErrorPolykey;

--- a/src/Timer.ts
+++ b/src/Timer.ts
@@ -13,7 +13,7 @@ class Timer<T = void>
    * Delay in milliseconds
    * This may be `Infinity`
    */
-  public readonly delay: number;
+  protected delay_: number;
 
   /**
    * If it is lazy, the timer will not eagerly reject
@@ -33,7 +33,7 @@ class Timer<T = void>
    * Guaranteed to be weakly monotonic within the process lifetime
    * Compare this with `performance.now()` not `Date.now()`
    */
-  public readonly scheduled?: Date;
+  protected scheduled_?: Date;
 
   /**
    * Handler to be executed
@@ -125,7 +125,7 @@ class Timer<T = void>
       }
     }
     this.handler = handler;
-    this.delay = delay;
+    this.delay_ = delay;
     this.lazy = lazy;
     let abortController: AbortController;
     if (typeof controller === 'function') {
@@ -150,7 +150,7 @@ class Timer<T = void>
     if (isFinite(delay)) {
       this.timeoutRef = setTimeout(() => void this.fulfill(), delay);
       this.timestamp = new Date(performance.timeOrigin + performance.now());
-      this.scheduled = new Date(this.timestamp.getTime() + delay);
+      this.scheduled_ = new Date(this.timestamp.getTime() + delay);
     } else {
       // Infinite interval, make sure you are cancelling the `Timer`
       // otherwise you will keep the process alive
@@ -168,16 +168,34 @@ class Timer<T = void>
   }
 
   /**
+   * Timestamp when this is scheduled to finish and execute the handler
+   * Guaranteed to be weakly monotonic within the process lifetime
+   * Compare this with `performance.now()` not `Date.now()`
+   */
+  public get scheduled(): Date | undefined {
+    return this.scheduled_;
+  }
+
+  /**
+   * Delay in milliseconds
+   * This may be `Infinity`
+   */
+  public get delay(): number {
+    return this.delay_;
+  }
+
+  /**
    * Gets the remaining time in milliseconds
    * This will return `Infinity` if `delay` is `Infinity`
    * This will return `0` if status is `settling` or `settled`
    */
   public getTimeout(): number {
     if (this._status !== null) return 0;
-    if (this.scheduled == null) return Infinity;
+    if (this.scheduled_ == null) return Infinity;
     return Math.max(
       Math.trunc(
-        this.scheduled.getTime() - (performance.timeOrigin + performance.now()),
+        this.scheduled_.getTime() -
+          (performance.timeOrigin + performance.now()),
       ),
       0,
     );
@@ -240,6 +258,43 @@ class Timer<T = void>
     controller?: PromiseCancellableController,
   ): PromiseCancellable<T> {
     return this.p.finally(onFinally, controller);
+  }
+
+  /**
+   * Refreshes the timer to the original delay and updates the scheduled time.
+   * If the timer has already ended this does nothing.
+   */
+  public refresh(): void {
+    if (this.timeoutRef != null) {
+      this.timeoutRef.refresh();
+      this.scheduled_ = new Date(
+        performance.timeOrigin + performance.now() + this.delay_,
+      );
+    }
+  }
+
+  /**
+   * Resets the timer with a new delay and updates the scheduled time and delay.
+   */
+  public reset(delay: number): void {
+    if (this.timeoutRef) {
+      // This needs to re-create the timeout with the constructor logic.
+      clearTimeout(this.timeoutRef);
+      // If the delay is Infinity, this promise will never resolve
+      // it may still reject however
+      this.delay_ = delay;
+      if (isFinite(delay)) {
+        this.timeoutRef = setTimeout(() => void this.fulfill(), delay);
+        this.scheduled_ = new Date(
+          performance.timeOrigin + performance.now() + delay,
+        );
+      } else {
+        // Infinite interval, make sure you are cancelling the `Timer`
+        // otherwise you will keep the process alive
+        this.timeoutRef = setInterval(() => {}, 2 ** 31 - 1);
+        this.scheduled_ = undefined;
+      }
+    }
   }
 
   protected async fulfill(): Promise<void> {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,8 @@
+import ErrorTimer from '@/ErrorTimer';
+
+class ErrorTimerEnded<T> extends ErrorTimer<T> {
+  static description = 'The timer has already ended';
+  exitCode = 70; // SOFTWARE error
+}
+
+export { ErrorTimer, ErrorTimerEnded };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as Timer } from './Timer';
+export * as errors from './errors';

--- a/tests/Timer.test.ts
+++ b/tests/Timer.test.ts
@@ -1,5 +1,6 @@
 import { performance } from 'perf_hooks';
 import Timer from '@/Timer';
+import * as timerErrors from '@/errors';
 import { sleep } from './utils';
 
 describe(Timer.name, () => {
@@ -224,7 +225,7 @@ describe(Timer.name, () => {
       await expect(timer).rejects.toBe('error');
     });
   });
-  test('refresh updates timer scheduled time', async () => {
+  test('Refresh updates timer scheduled time', async () => {
     const t = new Timer({ delay: 50 });
     const scheduledTimeInitial = t.scheduled;
     await sleep(20);
@@ -236,11 +237,13 @@ describe(Timer.name, () => {
     expect(
       new Date(performance.timeOrigin + performance.now()),
     ).toBeAfterOrEqualTo(scheduledTimeNew!);
-    // Refresh after ending shouldn't do anything
-    t.refresh();
-    expect(t.scheduled).toEqual(scheduledTimeNew);
   });
-  test('reset updates timer scheduled time and delay', async () => {
+  test('Refresh throws error when timer has ended', async () => {
+    const t = new Timer({ delay: 1 });
+    await t;
+    expect(() => t.refresh()).toThrowError(timerErrors.ErrorTimerEnded);
+  });
+  test('Reset updates timer scheduled time and delay', async () => {
     const t = new Timer({ delay: 50 });
     const scheduledTimeInitial = t.scheduled;
     await sleep(20);
@@ -256,9 +259,10 @@ describe(Timer.name, () => {
     expect(
       new Date(performance.timeOrigin + performance.now()),
     ).toBeAfterOrEqualTo(scheduledTimeNew!);
-    // Reset after ending shouldn't do anything
-    t.reset(1000);
-    expect(t.scheduled).toEqual(scheduledTimeNew);
-    expect(t.delay).toEqual(100);
+  });
+  test('Reset throws error when timer has ended', async () => {
+    const t = new Timer({ delay: 1 });
+    await t;
+    expect(() => t.reset(100)).toThrowError(timerErrors.ErrorTimerEnded);
   });
 });

--- a/tests/Timer.test.ts
+++ b/tests/Timer.test.ts
@@ -224,4 +224,41 @@ describe(Timer.name, () => {
       await expect(timer).rejects.toBe('error');
     });
   });
+  test('refresh updates timer scheduled time', async () => {
+    const t = new Timer({ delay: 50 });
+    const scheduledTimeInitial = t.scheduled;
+    await sleep(20);
+    // Refresh should update the timer
+    t.refresh();
+    const scheduledTimeNew = t.scheduled;
+    expect(scheduledTimeNew).toBeAfter(scheduledTimeInitial!);
+    await t;
+    expect(
+      new Date(performance.timeOrigin + performance.now()),
+    ).toBeAfterOrEqualTo(scheduledTimeNew!);
+    // Refresh after ending shouldn't do anything
+    t.refresh();
+    expect(t.scheduled).toEqual(scheduledTimeNew);
+  });
+  test('reset updates timer scheduled time and delay', async () => {
+    const t = new Timer({ delay: 50 });
+    const scheduledTimeInitial = t.scheduled;
+    await sleep(20);
+    // Refresh should update the timer
+    t.reset(100);
+    const scheduledTimeNew = t.scheduled;
+    expect(t.delay).toEqual(100);
+    expect(scheduledTimeNew).toBeAfter(scheduledTimeInitial!);
+    expect(
+      scheduledTimeNew!.getTime() - scheduledTimeInitial!.getTime(),
+    ).toBeGreaterThanOrEqual(55);
+    await t;
+    expect(
+      new Date(performance.timeOrigin + performance.now()),
+    ).toBeAfterOrEqualTo(scheduledTimeNew!);
+    // Reset after ending shouldn't do anything
+    t.reset(1000);
+    expect(t.scheduled).toEqual(scheduledTimeNew);
+    expect(t.delay).toEqual(100);
+  });
 });


### PR DESCRIPTION
### Description

This adds the `refresh` and `reset` features to the timer.

### Issues Fixed

* Fixes #5 

### Tasks
- [x] 1. Add `refresh` and `reset` features.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
